### PR TITLE
Made collapse turn off editing

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,67 @@
+{
+    "passfail"      : false,
+    "maxerr"        : 100,
+
+    "browser"       : false,
+    "node"          : false,
+    "rhino"         : false,
+    "couch"         : false,
+    "wsh"           : false,
+
+    "jquery"        : false,
+    "prototypejs"   : false,
+    "mootools"      : false,
+    "dojo"          : false,
+
+    "debug"         : false,
+    "devel"         : false,
+
+    "esnext"        : true,
+    "strict"        : true,
+    "globalstrict"  : true,
+
+    "asi"           : false,
+    "laxbreak"      : false,
+    "bitwise"       : true,
+    "boss"          : false,
+    "curly"         : true,
+    "eqeqeq"        : false,
+    "eqnull"        : false,
+    "evil"          : false,
+    "expr"          : false,
+    "forin"         : false,
+    "immed"         : true,
+    "latedef"       : false,
+    "loopfunc"      : false,
+    "noarg"         : true,
+    "regexp"        : false,
+    "regexdash"     : false,
+    "scripturl"     : false,
+    "shadow"        : false,
+    "supernew"      : false,
+    "undef"         : true,
+    "unused"         : true,
+
+    "newcap"        : true,
+    "noempty"       : true,
+    "nonew"         : true,
+    "nomen"         : false,
+    "onevar"        : false,
+    "onecase"       : true,
+    "plusplus"      : false,
+    "proto"         : false,
+    "sub"           : true,
+    "trailing"      : true,
+    "white"         : false,
+
+    "predef": [
+      "describe",
+      "it",
+      "before",
+      "beforeEach",
+      "after",
+      "afterEach",
+      "expect"
+    ],
+    "maxlen": 80
+}

--- a/component.json
+++ b/component.json
@@ -9,6 +9,7 @@
     "lodash/lodash": "2.3.0",
     "stagas/binder": "0.0.1",
     "component/emitter": "1.1.0",
+    "yields/prevent": "0.0.2",
     "component/classes": "1.1.4",
     "component/trim": "0.0.1",
     "caolan/async": "f01b3992fbe7aa2f4881152143608ad666aea1cc",

--- a/index.js
+++ b/index.js
@@ -392,7 +392,7 @@ UserList.prototype._deactivateEditing = function() {
   classes(this.el).remove('gi-editing');
 };
 
-UserList.prototype._handleUserMeta = function(user, keyName) {
+UserList.prototype._handleUserMeta = function(user, keyName, cb) {
   // Ignore user properties that don't affect the user list.
   if (!colors.isUserProperty(keyName) && !DISPLAYNAME_REGEX.test(keyName) &&
       !AVATARURL_REGEX.test(keyName)) {
@@ -403,23 +403,21 @@ UserList.prototype._handleUserMeta = function(user, keyName) {
 
   var self = this;
 
-  userView.render(user, function(err) {
-    if (err) {
-      throw err;
-    }
-
+  userView.render(user, function() {
     if (user.id == self._userCache.getLocalUser().id) {
       self._deactivateEditing();
+    }
+
+    if (cb) {
+      return cb();
     }
   });
 };
 
 UserList.prototype._handleJoinEvent = function(user) {
   var userView = new UserList._UserView(this);
-  userView.render(user, function(err) {
-    if (err) {
-      throw err;
-    }
+  userView.render(user, function() {
+
   });
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -455,6 +455,12 @@ describe('User-List Component', function() {
       });
     });
 
+    afterEach(function(done) {
+      userList.destroy(function() {
+        done();
+      });
+    });
+
     it('toggles when collapse is clicked', function() {
       userList._handleCollapseToggle();
 
@@ -541,6 +547,12 @@ describe('User-List Component', function() {
 
         fakeUserView.render.reset();
 
+        done();
+      });
+    });
+
+    afterEach(function(done) {
+      userList.destroy(function() {
         done();
       });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -205,6 +205,12 @@ describe('User-List Component', function() {
   });
 
   describe('initialize', function() {
+    afterEach(function(done) {
+      userList.destroy(function() {
+        done();
+      });
+    });
+
     it('hides the options when disabled', function(done) {
       userList = new UserList({
         room: fakeRoom,

--- a/user-list.css
+++ b/user-list.css
@@ -10,7 +10,7 @@
   background-repeat: no-repeat;
 }
 
-/* 
+/*
    Userlist Element
    ========================================================================== */
 
@@ -32,7 +32,7 @@
   box-shadow: 0 1px 5px rgba(0,0,0,.2);
 }
 
-/* 
+/*
    Positioning
    ========================================================================== */
 
@@ -61,17 +61,17 @@
         border-radius: 0 3px 3px 0;
         border-left: 0;
       }
-    
+
     /* Custom Container */
     .gi-relative {
       position: relative;
     }
 
-/* 
+/*
    User List
    ========================================================================== */
-  
-/* Wrapper */ 
+
+/* Wrapper */
 .gi-userlist .gi-inner {
   display: block;
   margin: 0;
@@ -165,7 +165,7 @@
     margin-right: 20px;
   }
 
-  .gi-inner.collapsed .gi-user {
+  .gi-collapsed .gi-inner .gi-user {
     overflow: visible;
   }
 
@@ -206,12 +206,12 @@
       width: 107px;
     }
 
-    .gi-userlist .gi-options.set input {
+    .gi-userlist.gi-editing .gi-options input {
       display: block;
     }
 
-    .gi-userlist .gi-inner.collapsed .gi-name,
-    .gi-userlist .gi-options.collapsed {
+    .gi-userlist.gi-collapsed .gi-inner .gi-name,
+    .gi-userlist.gi-collapsed .gi-options {
       display: none;
       overflow: visible;
     }
@@ -232,12 +232,12 @@
       }
 
 
-    .gi-userlist .gi-options.set .gi-icon {
+    .gi-userlist.gi-editing .gi-options .gi-icon {
       margin: 12px 12px 0 0;
       background-position: -161px -5px;
     }
 
-/* 
+/*
    Collapse Toggle
    ========================================================================== */
 
@@ -275,19 +275,19 @@
         left: 0;
         border-radius: 0 0 3px 0;
       }
-      
+
       /* Icon switching */
       .gi-userlist.gi-right .gi-collapse .gi-icon,
-      .gi-userlist.gi-left .gi-collapse.collapsed .gi-icon {
+      .gi-userlist.gi-left.gi-collapsed .gi-collapse .gi-icon {
         background-position: -84px -5px;
       }
-      
+
       .gi-userlist.gi-left .gi-collapse .gi-icon,
-      .gi-userlist.gi-right .gi-collapse.collapsed .gi-icon {
+      .gi-userlist.gi-right.gi-collapsed .gi-collapse .gi-icon {
         background-position: -58px -5px;
       }
 
-/* 
+/*
    Helpers
    ========================================================================== */
 


### PR DESCRIPTION
This PR:
- Makes `gi-collapsed` a single class on the `.gi-user-list` element, rather than a class applied to three separate elements
- Makes `gi-editing` applied to the `.gi-user-list` element rather than the options element alone
- Removes `gi-ediiting` (editing mode) from the element when the user-list is toggled
- Adds a substantial amount of tests
